### PR TITLE
Fix Mixed Content errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,20 +8,20 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
   <!-- Google Fonts -->
-  <link href="http://fonts.googleapis.com/css?family=Quicksand|Headland+One" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Quicksand|Headland+One" rel="stylesheet">
 
   <!-- demo style and animations -->
   <link href="dist/demo.css" rel="stylesheet">
 
   <!-- jQuery and jmpress.js -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
   <script src="dist/jmpress.all.js"></script>
 </head>
 <body>
   <!-- NAVIGATION -->
   <ul class="nav">
     <li><a href="#home" class="go">HOME</a>&middot;
-    <li><a href="http://jmpressjs.github.com/docs/" target="_blank">DOCS</a>&middot;
+    <li><a href="https://jmpressjs.github.com/docs/" target="_blank">DOCS</a>&middot;
     <li><a href="#/about">ABOUT</a>&middot;
     <li><a href="#/features">FEATURES</a>&middot;
     <li><a href="#/examples">EXAMPLES</a>&nbsp;-&nbsp;


### PR DESCRIPTION
A font and jQuery were being loaded from HTTP URLs. Since, GitHub Pages enforces HTTPS, the page wouldn't display correctly since the browser wouldn't download them.
